### PR TITLE
Fix: use strict comparator

### DIFF
--- a/src/Brabijan/Images/ImagePipe.php
+++ b/src/Brabijan/Images/ImagePipe.php
@@ -201,7 +201,7 @@ class ImagePipe extends Nette\Object
 			$this->mkdir(dirname($thumbnailFile));
 			if (file_exists($originalFile)) {
 				$img = Nette\Image::fromFile($originalFile);
-				if ($flags == "crop") {
+				if ($flags === "crop") {
 					$img->crop('50%', '50%', $width, $height);
 				} else {
 					$img->resize($width, $height, $flags);


### PR DESCRIPTION
In some cases causes to call `Image::crop` method unintentionally.
